### PR TITLE
fix: project_path input updated

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -9,7 +9,6 @@ import (
 // Environment variables
 const apmTokenEnvName = "APM_COLLECTOR_TOKEN"
 const projectDirEnvName = "BITRISEIO_GIT_REPOSITORY_SLUG"
-const srcDir = "BITRISE_SOURCE_DIR"
 const stepSrcDirEnvName = "BITRISE_STEP_SOURCE_DIR"
 
 // Config file values
@@ -37,16 +36,11 @@ type Configs struct {
 
 // Returns the directory for the Android application.
 func projectDir(src string) (string, error) {
-	root, err := env(srcDir)
-	if err != nil {
-		return "", err
-	}
-
 	pDir, err := env(projectDirEnvName)
 	if err != nil {
 		return "", err
 	}
-	return path.Join(root, pDir, src), nil
+	return path.Join(pDir, src), nil
 }
 
 // Gets an environment variable, throws error when it is not present.

--- a/step.yml
+++ b/step.yml
@@ -69,7 +69,7 @@ toolkit:
     package_name: github.com/bitrise-steplib/bitrise-step-add-trace-sdk-android
 
 inputs:
-  - project_path:
+  - project_path: $BITRISE_SOURCE_DIR
     opts:
       title: "Path of the root project"
       summary: Path of the root project
@@ -77,7 +77,7 @@ inputs:
         The path for the root project. By default it will be the source directory, but in some cases (for example if you
         have a monorepo) you may want to specify which directory should be used for this step.
 
-        Example: /myproject1/
+        Example: $BITRISE_SOURCE_DIR/myproject1/
       is_required: true
   - gradle_options:
     opts:


### PR DESCRIPTION
Updated project_path input to use BITRISE_SOURCE_DIR
by default.

APM-2255
