### PR TITLE
chore: Release of add-trace-sdk-android step

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
     - BITRISE_STEP_ID: add-trace-sdk-android
-    - BITRISE_STEP_VERSION: "0.0.2"
+    - BITRISE_STEP_VERSION: "0.0.3"
     - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/bitrise-add-trace-sdk-android.git
     - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:richard-bogdan-bitrise/bitrise-steplib.git
 


### PR DESCRIPTION
Version bumped to 0.0.3.
