### PR TITLE
fix: String literals in build.gradle

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -174,6 +174,7 @@ workflows:
           run_if: true
           inputs:
             - project_location: $IT_SOURCE_DIR
+            - gradle_options: "--stacktrace"
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/src/main/java/io/bitrise/trace/step/InjectTraceTask.java
+++ b/src/main/java/io/bitrise/trace/step/InjectTraceTask.java
@@ -258,12 +258,12 @@ public class InjectTraceTask extends DefaultTask {
         final Matcher matcher = pattern.matcher(codeContent);
         final List<Range> literalsPos = findStringLiterals(codeContent);
         if (matcher.find()) {
-            boolean result = true;
+            boolean matcherFindResult = true;
             while (literalsPos.stream().anyMatch(it -> it.intersect(matcher.start()))) {
-                result = matcher.find();
+                matcherFindResult = matcher.find();
             }
-            if (!result) {
-                return result;
+            if (!matcherFindResult) {
+                return false;
             }
 
             final String updatedContent = codeContent.substring(0,

--- a/src/test/java/io/bitrise/trace/step/InjectTraceTaskTest.java
+++ b/src/test/java/io/bitrise/trace/step/InjectTraceTaskTest.java
@@ -425,6 +425,14 @@ public class InjectTraceTaskTest {
             "def stringName = \"buildscript {\"" +
             DUMMY_BUILD_GRADLE_CONTENT_1;
 
+    private final static String DUMMY_BUILD_GRADLE_CONTENT_3 = "\n" +
+            "someContent\n" +
+            " dependencies {" +
+            "   implementation fileTree(dir: 'libs', include: ['*.jar'])\n" +
+            "   implementation \"io.bitrise.trace:trace-sdk:0.0.7\"" +
+            "}" +
+            "\nsomeOtherContent";
+
     @Test
     public void updateBuildScriptContent_BuildScriptShouldBeUpdated() throws IOException {
         final File tempFile = tempFolder.newFile("build.gradle");
@@ -456,6 +464,15 @@ public class InjectTraceTaskTest {
     }
 
     @Test
+    public void updateBuildScriptContent_NoMatch() throws IOException {
+        final File tempFile = tempFolder.newFile("build.gradle");
+        FileUtils.writeStringToFile(tempFile, DUMMY_BUILD_GRADLE_CONTENT_3,  Charset.defaultCharset());
+
+        final boolean actual = InjectTraceTask.updateBuildScriptContent(tempFile.getPath());
+        assertThat(actual, equalTo(false));
+    }
+
+    @Test
     public void appendContentToTop_ContentShouldBeOnTheTop() throws IOException {
         final File tempFile = tempFolder.newFile("build.gradle");
         FileUtils.writeStringToFile(tempFile, String.format(DUMMY_BUILD_GRADLE_CONTENT_1, "\n"),
@@ -469,6 +486,14 @@ public class InjectTraceTaskTest {
         originalContent.add(0, dummyTopContent);
         final List<String> actual = Files.readAllLines(Paths.get(tempFile.getPath()), StandardCharsets.UTF_8);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void findStringLiterals_EmptyResult() {
+        final List<InjectTraceTask.Range> actual = InjectTraceTask.findStringLiterals(STRING_CONTENT);
+        final List<InjectTraceTask.Range> expected = new ArrayList<>();
+
+        assertThat(actual, is(expected));
     }
 
     @Test

--- a/src/test/java/io/bitrise/trace/step/InjectTraceTaskTest.java
+++ b/src/test/java/io/bitrise/trace/step/InjectTraceTaskTest.java
@@ -136,6 +136,8 @@ public class InjectTraceTaskTest {
     private static final String GREEDY_COMMENT_START = "/*";
     private static final String GREEDY_COMMENT_END = "*/";
     private static final String STRING_CONTENT = "This is a dummy String";
+    private static final String STRING_CONTENT_WITH_LITERAL = "def website =\"https://bitrise.io\"";
+    private static final String STRING_CONTENT_WITH_CHAR_LITERAL = "def website ='https://bitrise.io'";
 
     @Test
     public void removeCommentedCode_none() {
@@ -297,7 +299,48 @@ public class InjectTraceTaskTest {
         final String expected = String.format("\n%1$s\n", STRING_CONTENT);
         assertThat(actual, equalTo(expected));
     }
+
+    @Test
+    public void removeCommentedCode_DoNotModifyStrings() {
+        final ArrayList<String> codeLines = new ArrayList<String>() {{
+            add(STRING_CONTENT_WITH_LITERAL);
+        }};
+        final String actual = InjectTraceTask.removeCommentedCode(codeLines);
+        final String expected = STRING_CONTENT_WITH_LITERAL + "\n";
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void removeCommentedCode_DoNotModifyChars() {
+        final ArrayList<String> codeLines = new ArrayList<String>() {{
+            add(STRING_CONTENT_WITH_CHAR_LITERAL);
+        }};
+        final String actual = InjectTraceTask.removeCommentedCode(codeLines);
+        final String expected = STRING_CONTENT_WITH_CHAR_LITERAL + "\n";
+        assertThat(actual, equalTo(expected));
+    }
     //endregion
+
+    //region getIndexOfFromCode tests
+
+    @Test
+    public void getIndexOfFromCode_ShouldFind() {
+        final int actual = InjectTraceTask.getIndexOfFromCode(STRING_CONTENT, "dummy");
+        assertThat(actual, equalTo(10));
+    }
+
+    @Test
+    public void getIndexOfFromCode_StringLiteral_ShouldNotFind() {
+        final int actual = InjectTraceTask.getIndexOfFromCode(STRING_CONTENT_WITH_LITERAL, "http");
+        assertThat(actual, equalTo(-1));
+    }
+
+    @Test
+    public void getIndexOfFromCode_CharLiteral_ShouldNotFind() {
+        final int actual = InjectTraceTask.getIndexOfFromCode(STRING_CONTENT_WITH_CHAR_LITERAL, "http");
+        assertThat(actual, equalTo(-1));
+    }
+    // endRegion
 
     //region hasDependency tests
     private final static String DUMMY_DEPENDENCY_NAME = "dummy-dependency";


### PR DESCRIPTION
InjectTraceTask removed some String literals, when it contained
commenting chars. This has been fixed, String literals will not
be affected by the comment removal.
InjectTraceTask replaced first occurrence of buildscript,
but it should not be replaced if it is a String literal.
